### PR TITLE
Availability hecho

### DIFF
--- a/src/Application/Interfaces/IAvailabilityService.cs
+++ b/src/Application/Interfaces/IAvailabilityService.cs
@@ -1,0 +1,17 @@
+﻿using Application.Models.Request;
+using Application.Models.Response;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Application.Interfaces
+{
+    public interface IAvailabilityService
+    {
+        void InitDefaultAvailability(AvailabilityInitRequest dto);
+        List<AvailabilityResponseDto> GetAll();
+        void UpdateAvailability(AvailabilityInitRequest dto, string day);
+    }
+}

--- a/src/Application/Models/Request/AvailabilityInitRequest.cs
+++ b/src/Application/Models/Request/AvailabilityInitRequest.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Application.Models.Request
+{
+    public class AvailabilityInitRequest
+    {
+        [Required]
+        public TimeOnly StartTime { get; set; }
+
+        [Required]
+        public TimeOnly FinishTime { get; set; }
+
+        [Required]
+        public int Duration { get; set; }
+    }
+}

--- a/src/Application/Models/Response/AvailabilityResponseDto.cs
+++ b/src/Application/Models/Response/AvailabilityResponseDto.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Application.Models.Response
+{
+    public class AvailabilityResponseDto
+    {
+        public string? DayOfWeek { get; set; } 
+        public TimeOnly StartTime { get; set; }
+        public TimeOnly FinishTime { get; set; }
+        public int Duration { get; set; }
+    }
+}

--- a/src/Application/Services/AvailabilityService.cs
+++ b/src/Application/Services/AvailabilityService.cs
@@ -1,0 +1,74 @@
+﻿using Application.Interfaces;
+using Application.Models.Request;
+using Application.Models.Response;
+using Domain.Entities;
+using Domain.Exceptions;
+using Domain.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Application.Services
+{
+    public class AvailabilityService : IAvailabilityService
+    {
+        private readonly IAvailabilityRepository _availabilityRepository;
+        public AvailabilityService(IAvailabilityRepository availabilityRepository)
+        {
+            _availabilityRepository = availabilityRepository;
+        }
+
+        public void InitDefaultAvailability(AvailabilityInitRequest dto)
+        {
+            var existingAvailabilities = _availabilityRepository.GetAll();
+
+            if (existingAvailabilities != null && existingAvailabilities.Any())
+            {
+                throw new BadRequestException("Ya existe disponibilidad cargada.");
+            }
+
+            foreach (DayOfWeek day in Enum.GetValues(typeof(DayOfWeek)))
+            {
+                var availability = new Availability
+                {
+                    DayOfWeek = day,
+                    StartTime = dto.StartTime,
+                    FinishTime = dto.FinishTime,
+                    Duration = dto.Duration
+                };
+
+                _availabilityRepository.Add(availability);
+            }
+        }
+
+        public List<AvailabilityResponseDto> GetAll()
+        {
+            var availabilities = _availabilityRepository.GetAll();
+            var response = new List<AvailabilityResponseDto>();
+
+            foreach (var availability in availabilities)
+            {
+                var dto = new AvailabilityResponseDto();
+                dto.DayOfWeek = availability.DayOfWeek.ToString();
+                dto.StartTime = availability.StartTime;
+                dto.FinishTime = availability.FinishTime;
+                dto.Duration = availability.Duration;
+
+                response.Add(dto);
+            }
+
+            return response;
+        }
+
+        public void UpdateAvailability(AvailabilityInitRequest dto, string day)
+        {
+            var availabilityToEdit = _availabilityRepository.GetByDay(day);
+            availabilityToEdit.StartTime = dto.StartTime;
+            availabilityToEdit.FinishTime = dto.FinishTime;
+            availabilityToEdit.Duration = dto.Duration;
+            _availabilityRepository.Update(availabilityToEdit);
+        }
+    }
+}

--- a/src/Domain/Interfaces/IAvailabilityRepository.cs
+++ b/src/Domain/Interfaces/IAvailabilityRepository.cs
@@ -1,0 +1,14 @@
+﻿using Domain.Entities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Domain.Interfaces
+{
+    public interface IAvailabilityRepository : IBaseRepository<Availability>
+    {
+        Availability? GetByDay(string day);
+    }
+}

--- a/src/Infrastructure/Data/AvailabilityRepository.cs
+++ b/src/Infrastructure/Data/AvailabilityRepository.cs
@@ -1,0 +1,22 @@
+﻿using Domain.Entities;
+using Domain.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Infrastructure.Data
+{
+    public class AvailabilityRepository : BaseRepository<Availability>, IAvailabilityRepository
+    {
+        public AvailabilityRepository(ApplicationDbContext context) : base(context)
+        {
+        }
+
+        public Availability GetByDay(string day) 
+        {
+            return _dbContext.Availabilities.FirstOrDefault(a => a.DayOfWeek.ToString().ToLower() == day.ToLower());
+        }
+    }
+}

--- a/src/Web/Controllers/AvailabilityController.cs
+++ b/src/Web/Controllers/AvailabilityController.cs
@@ -1,0 +1,53 @@
+﻿using Application.Interfaces;
+using Application.Models.Request;
+using Domain.Exceptions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Web.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class AvailabilityController : ControllerBase
+    {
+        private readonly IAvailabilityService _availabilityService;
+        public AvailabilityController(IAvailabilityService availabilityService)
+        {
+            _availabilityService = availabilityService;
+        }
+
+        [HttpPost("[Action]")]
+        public IActionResult Create([FromBody] AvailabilityInitRequest request)
+        {
+            try
+            {
+                _availabilityService.InitDefaultAvailability(request);
+                return Ok("Se han creado las disponibilidades correctamente");
+            }
+            catch (BadRequestException ex)
+            {
+                return BadRequest(ex.Message);
+            }
+        }
+
+        [HttpGet("[Action]")]
+        public IActionResult GetAll()
+        {
+            return Ok(_availabilityService.GetAll());
+        }
+
+        [HttpPut("[Action]/{day}")]
+        public IActionResult UpdateAvailability([FromBody] AvailabilityInitRequest dto, string day)
+        {
+            try
+            {
+                _availabilityService.UpdateAvailability(dto, day);
+                return Ok("Se ha actualizado la disponibilidad correctamente");
+            }
+            catch (NotFoundException ex)
+            {
+                return NotFound(ex.Message);
+            }
+        }
+    }
+}

--- a/src/Web/Program.cs
+++ b/src/Web/Program.cs
@@ -68,6 +68,7 @@ builder.Services.AddAuthentication("Bearer")
 #region Repositories
 builder.Services.AddScoped<IUserRepository, UserRepository>();
 builder.Services.AddScoped<ISubscriptionRepository, SubscriptionRepository>();
+builder.Services.AddScoped<IAvailabilityRepository, AvailabilityRepository>();
 #endregion
 
 #region services
@@ -80,6 +81,7 @@ builder.Services.Configure<AuthenticationService.AuthenticationServiceOptions>(
 builder.Services.AddScoped<IUserService, UserService>();
 builder.Services.AddScoped<ISubscriptionService, SubscriptionService>();
 builder.Services.AddScoped<ICustomAuthenticationService, AuthenticationService>();
+builder.Services.AddScoped<IAvailabilityService, AvailabilityService>();
 
 #endregion
 


### PR DESCRIPTION
Cree el servicio AvailabilityService con los métodos:
- InitDefaultAvailability: inicializa la disponibilidad para todos los días de la semana según los datos recibidos.
- GetAll: obtiene todas las disponibilidades existentes.
- UpdateAvailability: actualiza la disponibilidad de un día específico.

Implemente los DTOs necesarios para request y response (AvailabilityInitRequest, AvailabilityResponseDto).

Agregué validación para evitar la creación de disponibilidades duplicadas en InitDefaultAvailability.

